### PR TITLE
Use error details in messages

### DIFF
--- a/src/app/user-controls/form-error/form-error.directive.ts
+++ b/src/app/user-controls/form-error/form-error.directive.ts
@@ -69,14 +69,15 @@ export class FormErrorDirective implements OnDestroy, OnChanges {
 
   getStandardErrorMessage(error: ValidationError): string {
     const label = this.fieldLabel || 'Input'
+    const errorDetails = this.fieldControl?.getError(error) // {requiredLength: number, minLength: number}
 
     switch (error) {
       case 'required':
         return `${label} is required`
       case 'minlength':
-        return `${label} must be at least 2 characters`
+        return `${label} must be at least ${errorDetails?.requiredLength ?? 2} characters`
       case 'maxlength':
-        return `${label} can\'t exceed 50 characters`
+        return `${label} can\'t exceed ${errorDetails?.requiredLength ?? 50} characters`
       case 'invalid':
         return `A valid ${label} is required`
     }

--- a/src/app/user/profile/profile.component.ts
+++ b/src/app/user/profile/profile.component.ts
@@ -31,7 +31,7 @@ import { IUSState, USStateFilter } from './data'
 export class ProfileComponent extends BaseFormComponent<IUser>
   implements OnInit, OnDestroy {
   Role = Role
-  PhoneTypes = $enum(PhoneType).getValues()
+  PhoneTypes = $enum(PhoneType).getKeys()
 
   states$: Observable<IUSState[]>
   userError = ''
@@ -200,7 +200,7 @@ export class ProfileComponent extends BaseFormComponent<IUser>
   }
 
   convertTypeToPhoneType(type: string): PhoneType {
-    return $enum(PhoneType).asValueOrThrow(type)
+    return PhoneType[$enum(PhoneType).asKeyOrThrow(type)]
   }
 
   simulateLazyLoadedInitData() {

--- a/src/app/user/profile/profile.component.ts
+++ b/src/app/user/profile/profile.component.ts
@@ -31,7 +31,7 @@ import { IUSState, USStateFilter } from './data'
 export class ProfileComponent extends BaseFormComponent<IUser>
   implements OnInit, OnDestroy {
   Role = Role
-  PhoneTypes = $enum(PhoneType).getKeys()
+  PhoneTypes = $enum(PhoneType).getValues()
 
   states$: Observable<IUSState[]>
   userError = ''


### PR DESCRIPTION
# Feature/Change Description

This adds an enhancement to the FormError directive, that utilizes the error Object passed back from the Reactive Forms validators to help construct the Min/Max length error messages.

# Developer Checklist

- [ ] Updated documentation or README.md
- [ ] If adding new feature(s), added and ran unit tests
- [ ] If create new release, bumped version number
- [ ] Ran `npm run style:fix` for code style enforcement
- [ ] Ran `npm run lint:fix` for linting
- [ ] Ran `npm audit` to discover vulnerabilities
